### PR TITLE
cleaned up html-routes to direct to dashboard and not members

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "development": {
     "username": "root",
-    "password": null,
+    "password": "bootcamp",
     "database": "shoppinDB",
     "host": "127.0.0.1",
     "dialect": "mysql"

--- a/public/login.html
+++ b/public/login.html
@@ -32,7 +32,7 @@
           <button type="submit" class="btn btn-default">Login</button>
         </form>
         <br />
-        <p>Or sign up <a href="/">here</a></p>
+        <p>Or sign up <a href="/signup.html">here</a></p>
       </div>
     </div>
   </div>
@@ -42,8 +42,4 @@
 
 </body>
 
-<<<<<<< HEAD
 </html>
-=======
-</html>
->>>>>>> develop

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -24,12 +24,20 @@ module.exports = function(app) {
 
   // Here we've add our isAuthenticated middleware to this route.
   // If a user who is not logged in tries to access this route they will be redirected to the signup page
-  app.get("/members", isAuthenticated, function(req, res) {
-    res.sendFile(path.join(__dirname, "../public/members.html"));
-  });
-
   app.get("/dashboard", isAuthenticated, function(req,res) {
     res.render("index");
   })
+
+  // if a user logs out they get directed to the landing/intro page again.
+  app.get("/logout", function(req,res) {
+    res.sendFile(path.join(__dirname, "../public/intro.html"))
+  })
+
+
+  // a test to see what happens if a signed in user tries to go to "localhost:8081/"
+  app.get("/members", function(req,res) {
+    res.sendFile(path.join(__dirname, "../public/members.html"))
+  })
+  
 
 };

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="container text-center" id="logo">
       <img class="rounded mx-auto" src="./images/Window.png" class="img-fluid" alt="Window Shoppin' logo">
-      <h2 id="subtitle">Welcome <span id="member-name"></span></h2>
+      <h2 id="subtitle">Welcome <span class="member-name"></span></h2>
     </div>
   </div>
   <div class="container">
@@ -39,4 +39,6 @@
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-  <script src="/js/dashboard.js" type="text/javascript"></script>
+<script src="/js/members.js" type="text/javascript"></script>
+<script src="/js/dashboard.js" type="text/javascript"></script>
+  


### PR DESCRIPTION
html routing tweaked abit. If you login or signup, dashboard page now populates with "welcome + your email". 
If you try to access localhost:8081/ you'll be directed to a draft page instead of an error